### PR TITLE
Proposing Browsers History to timeline plugin.

### DIFF
--- a/docs/5_Existing_plugins.md
+++ b/docs/5_Existing_plugins.md
@@ -169,3 +169,51 @@ Output example:
 2021-02-12 15:56:32.512,FAKEMACHINE,Event,Microsoft-Windows-Servicing:4 S-1-5-18 (KBWUClient-SelfUpdate-Aux Installed 0x0 WindowsUpdateAgent),\Windows\System32\winevt\Logs\Setup.evtx
 2022-10-24 01:46:29.681,FAKEMACHINE,Event,Microsoft-Windows-Servicing:2 S-1-5-18 (KBWUClient-SelfUpdate-Aux Installed 0x0 WindowsUpdateAgent),\Windows\System32\winevt\Logs\Setup.evtx
 ```
+
+### BrowsersHistoryToTimeline
+
+This plugin processes Browsers History files. It only supports SQLite database file. The plugin will automatically try to replay transactions files (contained in WAL file).
+
+Configuration snippet:
+
+```
+[...]
+  - BrowsersHistoryToTimeline:
+      archives: ["Browsers"]
+      sub_archives: ["Browsers_history.7z"]
+      match_pattern: [".*data$"]
+      sourcetype: ["Browsers history"]
+[...]
+```
+
+Output example:
+
+```
+021-02-12 15:56:30.372,FAKEMACHINE,Browsers history,TableName: moz_places - id: 1 - url: https://support.mozilla.org/products/firefox - title: None - rev_host: gro.allizom.troppus. - visit_count: 0 - hidden: 0 - typed: 0 - frecency: 137 - last_visit_date: None - guid: K-wMZzv_brcm - foreign_count: 1 - url_hash: 47358327123126 - description: None - preview_image_url: None - site_name: None - origin_id: 1 - recalc_frecency: 0 - alt_frecency: None - recalc_alt_frecency: 1 - ,<guid>_3_History_{00...00}.data
+```
+
+Additionnal configuration:
+
+Like `EventLogsToTimeline` plugin, a configuration file is available: `BrowsersHistoryToTimeline-timestampmap.json`. This file contains configuration about which column name must be considered as the event timestamp, for a given table. For each table, there **MUST** be one or zero column name. Theses values are used to add the desired timestamp to the event.
+
+```json
+{
+    "moz_bookmarks": "lastModified",        # Firefox
+    "moz_bookmarks_deleted": "dateRemoved",
+    "moz_historyvisits": "visit_date",
+    "moz_items_annos": "lastModified",
+    "moz_places": "last_visit_date",
+    "moz_places_metadatas": "updated_at",
+    "downloads": "end_time",                # Chrome
+    "urls": "last_visit_time",
+    "visits": "visit_time"
+}
+```
+
+#### Supported Browsers
+
+- Firefox (tested on version 133)
+
+- Chrome (tested on version 131). So I assume my plugin is compatible with Chromium based browsers (not tested).
+
+- **Not tested** on Safari (not supported on Windows since years).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
   "dfwinreg==20240229",
   "six==1.16.0",
   "pytz==2024.1",
+  "json>=2.0.9",
+  "sqlite3>=3.40.1"
 ]
 
 readme = "README.rst"
@@ -134,7 +136,7 @@ version = {attr = "orc2timeline.info.__version__"}
 where = ["src"]
 
 [tool.setuptools.package-data]
-orc2timeline = ["plugins/**/*.txt", "conf/*.yaml"]
+orc2timeline = ["plugins/**/*.txt", "plugins/**/*.json", "conf/*.yaml"]
 
 # ----------------------------------------------------------------------
 # Tox

--- a/src/orc2timeline/conf/Orc2Timeline.yaml
+++ b/src/orc2timeline/conf/Orc2Timeline.yaml
@@ -28,3 +28,9 @@ Plugins:
       sub_archives: ["NTFSInfo_i30Info.7z"]
       match_pattern: "^I30Info.*\\.csv$"
       sourcetype: "I30"
+
+  - BrowsersHistoryToTimeline:
+      archives: ["Browsers"]
+      sub_archives: ["Browsers_history.7z"]
+      match_pattern: [".*data$"]
+      sourcetype: ["Browsers history"]

--- a/src/orc2timeline/plugins/BrowsersHistoryToTimeline-timestampmap.json
+++ b/src/orc2timeline/plugins/BrowsersHistoryToTimeline-timestampmap.json
@@ -1,0 +1,11 @@
+{
+    "moz_bookmarks": "lastModified",
+    "moz_bookmarks_deleted": "dateRemoved",
+    "moz_historyvisits": "visit_date",
+    "moz_items_annos": "lastModified",
+    "moz_places": "last_visit_date",
+    "moz_places_metadatas": "updated_at",
+    "downloads": "end_time",
+    "urls": "last_visit_time",
+    "visits": "visit_time"
+}

--- a/src/orc2timeline/plugins/BrowsersHistoryToTimeline.py
+++ b/src/orc2timeline/plugins/BrowsersHistoryToTimeline.py
@@ -1,0 +1,112 @@
+"""Plugin to parse Browsers History files (SQLite only)."""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pathlib import Path
+if TYPE_CHECKING:
+    from threading import Lock
+
+    from orc2timeline.config import PluginConfig
+
+import sqlite3
+
+from orc2timeline.plugins.GenericToTimeline import Event, GenericToTimeline
+
+class BrowsersHistoryToTimeline(GenericToTimeline):
+    def __init__(
+        self,
+        config: PluginConfig,
+        orclist: list[str],
+        output_file_path: str,
+        hostname: str,
+        tmp_dir: str,
+        lock: Lock,
+    ) -> None:
+        """Construct.
+        Please note that I didn't defined self.file_header.
+        Because WAL files have different magic number than SQLite. self.file_header could only contains one byte array.
+        Please note also that the match_pattern couldn't be more precise than all .data files,
+        as filename nomenclature is not coherent between browsers.
+        """
+        super().__init__(config, orclist, output_file_path, hostname, tmp_dir, lock)
+
+        self.timestampmap_file = Path(__file__).parent / "BrowsersHistoryToTimeline-timestampmap.json"
+        self.timestampmap = self._parse_timestampmap_config_file(self.timestampmap_file)
+
+    def _get_complete_database(self, artefact: Path) -> None:
+        """wal file -> storing recent transactions before they are committed to the main database.
+        shm file -> shared memory file used for managing WAL operations.
+        To get a complete database, it is mandatory to replay pending transactions.
+        Otherwise, the database may not be complete.
+
+        There is maybe an error when the results of conn.execute("PRAGMA wal_checkpoint(FULL);") are (0, -1, -1).
+        This behaviour likely occurs when shm and wal files does not exists.
+        """
+        try:
+            with sqlite3.connect(Path(artefact)) as conn:
+                cursor = conn.cursor()
+                cursor.execute("PRAGMA integrity_check;")
+                results = cursor.fetchone()
+                logging.debug("Database integrity check result: %s", results[0])
+                logging.debug("Trying to replay transaction from wal and shm files to get a complete database.")
+                cursor = conn.execute("PRAGMA wal_checkpoint(FULL);")
+                results = cursor.fetchone()
+                conn.commit()
+                logging.debug("Replaying transactions successful! Checkpointed frames: %i. WAL size: %i. Frame written to database: %i.", results[0], results[1], results[2])
+        except Exception as e:
+            logging.warning("Unable to replay database (%s) transactions. Error: %s", artefact.name, e)
+
+    def _get_event(self, table_name: str, data: dict, source: str) -> Event:
+        from datetime import datetime, timedelta
+        timestamp = datetime(1970, 1, 1) # Will be set after if timestamp exists.
+        description = f"TableName: {table_name} - "
+        for key, value in data.items():
+            description += f"{key}: {value} - "
+            # If the value must be considered as the timestamp of the event.
+            if table_name in self.timestampmap and self.timestampmap[table_name] == key and value != None:
+                if value < 1_000_000_000: # Unix timestamp.
+                    timestamp = value / 1_000_000 # Convert into seconds.
+                    timestamp = datetime.fromtimestamp(timestamp)
+                else: # When timestamp comes from Webkit/Chromium.
+                    windows_epoch = datetime(1601, 1, 1)
+                    timestamp = windows_epoch + timedelta(microseconds=value)
+        return Event(
+                   timestamp=timestamp,
+                   source=source,
+                   description=description
+               )
+
+    def _parse_artefact(self, artefact: Path) -> None:
+        # Maybe not a perfect filter. The idea is to target only the sqlite file.
+        if not ("-shm_" in artefact.name or "-wal_" in artefact.name):
+            self._get_complete_database(artefact)
+            try:
+                with sqlite3.connect(Path(artefact)) as conn:
+                    conn.row_factory = sqlite3.Row
+                    cursor = conn.cursor()
+                    cursor.execute("SELECT name FROM main.sqlite_master WHERE type='table';")
+                    tables = cursor.fetchall()
+                    for table in tables:
+                        rows = cursor.execute(f"SELECT * FROM {table[0]};").fetchall()
+                        datas = [dict(row) for row in rows]
+                        for data in datas:
+                            self._add_event(self._get_event(table[0], data, Path(artefact).name))
+            except Exception as e:
+                logging.warning("Unable to parse artifacts from (%s). Error: %s", artefact.name, e)
+
+    def _parse_timestampmap_config_file(self, timestampmap_file: Path) -> dict[str, str]:
+        """Parse BrowsersHistoryToTimeline-timestampmap.json which contains config about
+        which column name must be considered as the event timestamps, for a given table.
+        For each table, there MUST be one or zero column name.
+        Theses values are used inside _get_event function to add the desired timestamp to the event.
+        Config format:
+        "<table_name>": "<desired_timestamp_column>"
+        """
+        import json
+        try:
+            with timestampmap_file.open(encoding="utf-8") as f:
+                return json.load(f)
+        except OSError as e:
+            logging.critical("Error while opening the timestamp map file %s: %s", timestampmap_file, e)


### PR DESCRIPTION
# Browsers History To Timeline

## Plugin purpose

Plugin to parse Browsers History files.

In the final timeline, *Description* field is fill with an extract of all the available tables. Formatting follows that of other plugins:

```
TableName: <table_name> - <Column_name>: <value> - ...
# Example:
TableName: moz_places - id: 1 - url: https://support.mozilla.org/products/firefox - title: None - rev_host: gro.allizom.troppus. - visit_count: 0 - hidden: 0 - typed: 0 - frecency: 137 - last_visit_date: None - guid: K-wMZzv_brcm - foreign_count: 1 - url_hash: 47358327123126 - description: None - preview_image_url: None - site_name: None - origin_id: 1 - recalc_frecency: 0 - alt_frecency: None - recalc_alt_frecency: 1 - 
```

## Plugin configuration

Please note that the `match_pattern` attribute couldn't be more precise than all `.data` files, as filename nomenclature is not coherent between browsers. I didn't defined `self.file_header`. Because WAL files have different magic number than SQLite. `self.file_header` could only contains one byte array. I think it's a good idea to use this variable to filter across several magic numbers. For example, it could be useful for selecting WAL and SQLite files, both at the same time. I had a quick look at the code and it seems that this limitation can be quickly lifted.

Like `EventLogsToTimeline` plugin, a configuration file is available: `BrowsersHistoryToTimeline-timestampmap.json`. This file contains configuration about which column name must be considered as the event timestamp, for a given table. For each table, there **MUST** be one or zero column name. Theses values are used inside `_get_event` function to add the desired timestamp to the event. After a quick analysis, I decided that the following values should be considered as the event timestamp. I don't know much about browsers forensic, so feel free to change according to your needs:

```json
{
    "moz_bookmarks": "lastModified",        # Firefox
    "moz_bookmarks_deleted": "dateRemoved",
    "moz_historyvisits": "visit_date",
    "moz_items_annos": "lastModified",
    "moz_places": "last_visit_date",
    "moz_places_metadatas": "updated_at",
    "downloads": "end_time",                # Chrome
    "urls": "last_visit_time",
    "visits": "visit_time"
}
```

There is a support for both WebKit/Chrome and Firefox (Unix) timestamp. If no timestamp is available, it will be set to Unix timestamp 0.

## Supported Browsers

- Firefox (tested on version 133)

- Chrome (tested on version 131). So I assume my plugin is compatible with Chromium based browsers (not tested).

- **Not tested** on Safari (not supported on Windows since years).

## Limitations

- Can only parse SQLite databases.

- I haven't tested transactions replays (WAL file) yet.

- Lot of Warnings because of my configuration choices (see plugin configuration part).